### PR TITLE
gitignore: add exports/ (compile artifacts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 lib*.a
 Makefile.dep
 Makefile
+exports/*


### PR DESCRIPTION
Just ignore compile artifacts to calm down `git status` in HermitCore project after building